### PR TITLE
Allow summary to be optional

### DIFF
--- a/atomfeed/atomsmasher.js
+++ b/atomfeed/atomsmasher.js
@@ -36,10 +36,6 @@ Encapsulating class for constructing atom feeds
     return output;
   }
 
-  function truncateWords(text, words) {
-    return text.split(/\s/, words || 20).join(' ');
-  }
-
   function toPermalink(title) {
     return '#' + encodeURIComponent(title);
   }
@@ -103,8 +99,7 @@ Encapsulating class for constructing atom feeds
       statichref: pathJoin([
         this.metadata.sitehref, 'static', toFileName(title)
       ]),
-      summary: tiddler.getFieldString('summary') ||
-        truncateWords(tiddler.getFieldString('text')),
+      summary: tiddler.getFieldString('summary'),
       author: tiddler.getFieldString('modifier') ||
         tiddler.getFieldString('creator') ||
         this.metadata.author
@@ -161,7 +156,11 @@ Encapsulating class for constructing atom feeds
       .end()
       .add('id').text(data.uuid).end()
       .add('updated').text(data.updated).end()
-      .add('summary').text(data.summary).end()
+      .bind(function() {
+        if (data.summary) {
+          this.add('summary').text(data.summary);
+        }
+      })
       .add('content')
         .attr('type', 'xhtml')
         .renderTiddler(data.title)

--- a/atomfeed/dombuilder.js
+++ b/atomfeed/dombuilder.js
@@ -103,6 +103,26 @@ Micro DSL for DOM creation and stringification.
   };
 
   /**
+   * Execute a callback and add it's result to the chain.
+   *
+   * Within the callback you can use `this` as if the chain was continuing
+   * inside. However, the return vaue is ignorred and the DomBuilder that
+   * `bind` was called on will be returned meaning `end()` wil not need to end
+   * this node.
+   *
+   * @method bind
+   * @param {Function} callback called with `this` as the current DomBuilder
+   * node. Return value is ignored.
+   * @return {DomBuilder} this DomBuilder in the hierarchy `.end()` not needed.
+   * @chainable
+   * @public
+   */
+  DomBuilder.prototype.bind = function bind(callback) {
+    callback.call(this);
+    return this;
+  };
+
+  /**
    * @method toDOM
    * @param {DOMDocument} [document=this.document] the document object to
    * propagate down the recursion chain


### PR DESCRIPTION
When viewing the feeds in some readers the summary (non rendered and truncated text kinda sucks. Seems they prefer the summary and ignore the content. But if summary is not there the content is rendered beautifully and the readers manage their own truncation/show/hiding. Win Win in my book. Also it still can show a text summary if the tiddler has a summary field.